### PR TITLE
Update VersionOne Java API version to make the plugin working with current VersionOne version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+## IntelliJ Files ##
+.idea/
+versionone-jenkins-notifier.iml
+
+## Jenkins Run Files (mvn hpi:run) ##
+work
+
 ## Directories created by Ant build file
 build/
 db/

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,14 @@
 					</execution>
 				</executions>
 			</plugin>
+            <!-- See Comment #2 (this is an alternative which is not a good practice!)
+            <plugin>
+                <groupId>org.jenkins-ci.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <configuration>
+                    <disabledTestInjection>true</disabledTestInjection>
+                </configuration>
+            </plugin>-->
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -242,10 +250,31 @@
 
 	<dependencies>
 
+        <!-- (Comment #1) Overriding the transitive dependency coming from com.versionone:VersionOne.SDK.Java.ObjectModel -->
+        <dependency>
+            <groupId>com.versionone</groupId>
+            <artifactId>VersionOne.SDK.Java.APIClient</artifactId>
+            <version>13.0.2</version>
+            <exclusions>
+                <!-- (Comment #2) exclude because Jenkins injected tests are failing otherwise -->
+                <exclusion>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
 		<dependency>
 			<groupId>com.versionone</groupId>
 			<artifactId>VersionOne.SDK.Java.ObjectModel</artifactId>
 			<version>12.1.0.150</version>
+            <exclusions>
+                <!-- See Comment #1 -->
+                <exclusion>
+                    <groupId>com.versionone</groupId>
+                    <artifactId>VersionOne.SDK.Java.APIClient</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 
 	    <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -241,12 +241,6 @@
 	</build>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>plugin</artifactId>
-			<version>1.509.2</version>
-			<type>pom</type>
-		</dependency>
 
 		<dependency>
 			<groupId>com.versionone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.versionone</groupId>
 	<artifactId>versionone-jenkins-notifier</artifactId>
-	<version>10.0.1</version>
+	<version>10.0.1-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<name>VersionOne Notifier for Jenkins</name>


### PR DESCRIPTION
Hi,
here a Pull request to use the newest version of the Java API (the plugin does not work with the current base code).
I excluded it from com.versionone:VersionOne.SDK.Java.ObjectModel (because it was used transitively) and add it directly so that it prepares the work to get rid off com.versionone:VersionOne.SDK.Java.ObjectModel.
Please also note that I had to exclude org.apache.maven.plugins:maven-gpg-plugin which was failing tests injected by Jenkins (maybe this is something that need to be changed in com.versionone:VersionOne.SDK.Java.APIClient).
Regards